### PR TITLE
dazai/mar 238 show add an item in todo section in empty week

### DIFF
--- a/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
+++ b/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
@@ -168,7 +168,7 @@ const Column = ({ title, items, column, onDragEnd, icon }) => {
         <DropIndicator beforeId={null} column={column} />
         <AddCard
           column={column}
-          updateItem={createItem}
+          createItem={createItem}
           totalItems={totalItems}
         />
       </div>

--- a/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
+++ b/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
@@ -297,34 +297,34 @@ const AddCard = ({ column, createItem, totalItems = 0 }) => {
     return "invisible group-hover/section:visible" // Default hover behavior
   }
 
-  return (
-    <div ref={addItemRef} className="">
-      {adding ? (
-        <motion.form layout onSubmit={handleSubmit}>
-          <textarea
-            ref={textareaRefTitle}
-            value={text}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-              setText(e.target.value)
-            }
-            onKeyDown={handleKeyDown}
-            autoFocus
-            placeholder="title"
-            className="w-full resize-none overflow-hidden truncate whitespace-pre-wrap break-words bg-transparent p-4 text-sm font-bold text-foreground outline-none placeholder:text-secondary-foreground focus:outline-none"
-            rows={1}
-          />
-          <button type="submit" style={{ display: "none" }}></button>
-        </motion.form>
-      ) : (
-        <motion.button
-          layout
-          onClick={() => setAdding(true)}
-          className={`hover-bg flex w-full items-center gap-2 rounded-lg p-4 text-sm ${getVisibilityClass()}`}
-        >
-          <Icon icon="ic:round-plus" className="text-[18px]" />
-          <p>New item</p>
-        </motion.button>
-      )}
-    </div>
-  )
-}
+return (
+  <div ref={addItemRef} className="">
+    {adding ? (
+      <motion.form layout onSubmit={handleSubmit}>
+        <textarea
+          ref={textareaRefTitle}
+          value={text}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setText(e.target.value)
+          }
+          onKeyDown={handleKeyDown}
+          /* eslint-disable-next-line jsx-a11y/no-autofocus */
+          autoFocus
+          placeholder="title"
+          className="w-full resize-none overflow-hidden truncate whitespace-pre-wrap break-words bg-transparent p-4 text-sm font-bold text-foreground outline-none placeholder:text-secondary-foreground focus:outline-none"
+          rows={1}
+        />
+        <button type="submit" style={{ display: "none" }}></button>
+      </motion.form>
+    ) : (
+      <motion.button
+        layout
+        onClick={() => setAdding(true)}
+        className={`hover-bg flex w-full items-center gap-2 rounded-lg p-4 text-sm ${getVisibilityClass()}`}
+      >
+        <Icon icon="ic:round-plus" className="text-[18px]" />
+        <p>New item</p>
+      </motion.button>
+    )}
+  </div>
+)

--- a/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
+++ b/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
@@ -222,7 +222,7 @@ interface AddCardProps {
   createItem: (session: string, data: Partial<CycleItem>) => void
 }
 
-const AddCard = ({ column, updateItem, totalItems = 0 }) => {
+const AddCard = ({ column, createItem, totalItems = 0 }) => {
   const [text, setText] = useState("")
   const [adding, setAdding] = useState(false)
   const { session } = useAuth()
@@ -241,15 +241,6 @@ const AddCard = ({ column, updateItem, totalItems = 0 }) => {
     (e?: React.FormEvent) => {
       e?.preventDefault()
       if (!text.trim().length) return
-<<<<<<< HEAD
-      const cycleDate = getEndOfCurrentWeek(new Date())
-      const data = {
-        cycleDate: cycleDate,
-        title: text.trim(),
-        status: column,
-      }
-      updateItem(session, data)
-=======
 
       const data: Partial<CycleItem> = {
         title: text.trim(),
@@ -261,7 +252,6 @@ const AddCard = ({ column, updateItem, totalItems = 0 }) => {
       }
 
       createItem(session, data)
->>>>>>> 7d9cce183a616acfbe82efc3137676881a9d5534
       handleCancel()
     },
     [createItem, column, session, text]

--- a/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
+++ b/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
@@ -129,6 +129,8 @@ const Column = ({ title, items, column, onDragEnd, icon }) => {
     setActive(false)
   }
 
+  const totalItems = items?.length || 0
+
   return (
     <div className="group/section flex size-full flex-1 flex-col gap-4 rounded-lg">
       <div className="flex items-center gap-2 text-xl text-foreground">
@@ -150,7 +152,11 @@ const Column = ({ title, items, column, onDragEnd, icon }) => {
           />
         ))}
         <DropIndicator beforeId={null} column={column} />
-        <AddCard column={column} updateItem={createItem} />
+        <AddCard
+          column={column}
+          updateItem={createItem}
+          totalItems={totalItems}
+        />
       </div>
     </div>
   )
@@ -202,7 +208,7 @@ interface AddCardProps {
   updateItem: (session: string, data: Partial<CycleItem>) => void
 }
 
-const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
+const AddCard = ({ column, updateItem, totalItems = 0 }) => {
   const [text, setText] = useState("")
   const [adding, setAdding] = useState(false)
   const { session } = useAuth()
@@ -221,15 +227,12 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
     (e?: React.FormEvent) => {
       e?.preventDefault()
       if (!text.trim().length) return
-
       const cycleDate = getEndOfCurrentWeek(new Date())
-
-      const data: Partial<CycleItem> = {
+      const data = {
         cycleDate: cycleDate,
         title: text.trim(),
         status: column,
       }
-
       updateItem(session, data)
       handleCancel()
     },
@@ -243,19 +246,6 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      /*
-      if (
-        adding &&
-        addItemRef.current &&
-        !addItemRef.current.contains(event.target as Node)
-      ) {
-        if (text.trim().length) {
-          handleSubmit()
-        } else {
-          handleCancel()
-      }
-      */
-
       if (
         adding &&
         addItemRef.current &&
@@ -264,7 +254,6 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
         handleCancel()
       }
     }
-
     document.addEventListener("mousedown", handleClickOutside)
     return () => {
       document.removeEventListener("mousedown", handleClickOutside)
@@ -282,6 +271,14 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
     }
   }
 
+  // Determine visibility class based on column and total items
+  const getVisibilityClass = () => {
+    if (column === "todo" && totalItems === 0) {
+      return "visible" // Always visible for todo column when no items
+    }
+    return "invisible group-hover/section:visible" // Default hover behavior
+  }
+
   return (
     <div ref={addItemRef} className="">
       {adding ? (
@@ -293,7 +290,6 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
               setText(e.target.value)
             }
             onKeyDown={handleKeyDown}
-            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             placeholder="title"
             className="w-full resize-none overflow-hidden truncate whitespace-pre-wrap break-words bg-transparent p-4 text-sm font-bold text-foreground outline-none placeholder:text-secondary-foreground focus:outline-none"
@@ -305,7 +301,7 @@ const AddCard: React.FC<AddCardProps> = ({ column, updateItem }) => {
         <motion.button
           layout
           onClick={() => setAdding(true)}
-          className="hover-bg invisible flex w-full items-center gap-2 rounded-lg p-4 text-sm group-hover/section:visible"
+          className={`hover-bg flex w-full items-center gap-2 rounded-lg p-4 text-sm ${getVisibilityClass()}`}
         >
           <Icon icon="ic:round-plus" className="text-[18px]" />
           <p>New item</p>

--- a/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
+++ b/apps/frontend/src/components/ThisWeek/CustomKanban.tsx
@@ -297,34 +297,35 @@ const AddCard = ({ column, createItem, totalItems = 0 }) => {
     return "invisible group-hover/section:visible" // Default hover behavior
   }
 
-return (
-  <div ref={addItemRef} className="">
-    {adding ? (
-      <motion.form layout onSubmit={handleSubmit}>
-        <textarea
-          ref={textareaRefTitle}
-          value={text}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-            setText(e.target.value)
-          }
-          onKeyDown={handleKeyDown}
-          /* eslint-disable-next-line jsx-a11y/no-autofocus */
-          autoFocus
-          placeholder="title"
-          className="w-full resize-none overflow-hidden truncate whitespace-pre-wrap break-words bg-transparent p-4 text-sm font-bold text-foreground outline-none placeholder:text-secondary-foreground focus:outline-none"
-          rows={1}
-        />
-        <button type="submit" style={{ display: "none" }}></button>
-      </motion.form>
-    ) : (
-      <motion.button
-        layout
-        onClick={() => setAdding(true)}
-        className={`hover-bg flex w-full items-center gap-2 rounded-lg p-4 text-sm ${getVisibilityClass()}`}
-      >
-        <Icon icon="ic:round-plus" className="text-[18px]" />
-        <p>New item</p>
-      </motion.button>
-    )}
-  </div>
-)
+  return (
+    <div ref={addItemRef} className="">
+      {adding ? (
+        <motion.form layout onSubmit={handleSubmit}>
+          <textarea
+            ref={textareaRefTitle}
+            value={text}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setText(e.target.value)
+            }
+            onKeyDown={handleKeyDown}
+            /* eslint-disable-next-line jsx-a11y/no-autofocus */
+            autoFocus
+            placeholder="title"
+            className="w-full resize-none overflow-hidden truncate whitespace-pre-wrap break-words bg-transparent p-4 text-sm font-bold text-foreground outline-none placeholder:text-secondary-foreground focus:outline-none"
+            rows={1}
+          />
+          <button type="submit" style={{ display: "none" }}></button>
+        </motion.form>
+      ) : (
+        <motion.button
+          layout
+          onClick={() => setAdding(true)}
+          className={`hover-bg flex w-full items-center gap-2 rounded-lg p-4 text-sm ${getVisibilityClass()}`}
+        >
+          <Icon icon="ic:round-plus" className="text-[18px]" />
+          <p>New item</p>
+        </motion.button>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/lib/store/cycle.store.ts
+++ b/apps/frontend/src/lib/store/cycle.store.ts
@@ -248,6 +248,7 @@ export const useCycleItemStore = create<ExtendedCycleItemStore>((set) => ({
   createItem: async (session: string, item: Partial<CycleItem>) => {
     set((state) => ({
       inbox: { ...state.inbox, isLoading: true, error: null },
+      thisWeek: { ...state.thisWeek, isLoading: true, error: null },
       isLoading: true,
       error: null,
     }))
@@ -260,6 +261,11 @@ export const useCycleItemStore = create<ExtendedCycleItemStore>((set) => ({
       set((state) => ({
         inbox: {
           items: [data.response, ...state.inbox.items],
+          isLoading: false,
+          error: null,
+        },
+        thisWeek: {
+          items: [data.response, ...state.thisWeek.items],
           isLoading: false,
           error: null,
         },
@@ -276,6 +282,11 @@ export const useCycleItemStore = create<ExtendedCycleItemStore>((set) => ({
       set((state) => ({
         inbox: {
           ...state.inbox,
+          error: errorMessage,
+          isLoading: false,
+        },
+        thisWeek: {
+          ...state.thisWeek,
           error: errorMessage,
           isLoading: false,
         },


### PR DESCRIPTION
- [x] fix refresh on creating item at this-week 
- [x] show add an item in todo section in empty week 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visibility logic for the "Add Card" button in the Kanban board, making it more intuitive based on column type and item count.
	- Introduced a method to fetch items specifically for the "This Week" view, improving item management.
	- Improved item creation and state management for the "This Week" view, ensuring a smoother user experience.

- **Bug Fixes**
	- Updated error handling for item creation, ensuring consistent feedback across different views.

- **Refactor**
	- Streamlined method signatures and internal logic for better clarity and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->