### PR TITLE
dazai/mar-272-treat-url-paste-in-inbox-similar-to-reading-list

### DIFF
--- a/apps/frontend/src/components/AddToSpace.tsx
+++ b/apps/frontend/src/components/AddToSpace.tsx
@@ -52,10 +52,6 @@ export function AddToSpace({ itemId }) {
     }
   }
 
-  if (!spaces?.length) {
-    return <div>Loading...</div>
-  }
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/apps/frontend/src/components/Inbox/InboxAddItem.tsx
+++ b/apps/frontend/src/components/Inbox/InboxAddItem.tsx
@@ -79,7 +79,7 @@ export const InboxAddItem: React.FC = () => {
       // Prepare the item data
       const data: Partial<CycleItem> = {
         title: finalTitle,
-        type: linkDetected ? "link" : "text",
+        type: linkDetected ? "link" : "Issue",
       }
 
       if (linkDetected) {

--- a/apps/frontend/src/components/Inbox/InboxItems.tsx
+++ b/apps/frontend/src/components/Inbox/InboxItems.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuContent,
   ContextMenuItem,
 } from "@radix-ui/react-context-menu"
+import Image from "next/image"
 
 import { useAuth } from "@/src/contexts/AuthContext"
 import { CycleItem } from "@/src/lib/@types/Items/Cycle"
@@ -186,9 +187,13 @@ export const InboxItems: React.FC = () => {
                           className="mt-0.5 text-[18px]"
                         />
                       </button>
-                      <span className="mt-1.5 size-2 rounded bg-white">
-                        {item.metadata?.favicon}
-                      </span>
+                      <img
+                        src={item.metadata?.favicon}
+                        alt="favicon"
+                        width={16}
+                        height={16}
+                        className="size-5 shrink-0"
+                      />
                       <p className="mr-1">{item.title}</p>
                       <div className="flex items-center gap-2 text-xs text-secondary-foreground">
                         <button className="invisible focus:outline-none focus:ring-0 group-hover:visible">

--- a/apps/frontend/src/components/Inbox/InboxItems.tsx
+++ b/apps/frontend/src/components/Inbox/InboxItems.tsx
@@ -11,6 +11,7 @@ import {
 } from "@radix-ui/react-context-menu"
 import Image from "next/image"
 
+import ImageWithFallback from "../ui/ImageWithFallback"
 import { useAuth } from "@/src/contexts/AuthContext"
 import { CycleItem } from "@/src/lib/@types/Items/Cycle"
 import { useCycleItemStore } from "@/src/lib/store/cycle.store"
@@ -187,15 +188,19 @@ export const InboxItems: React.FC = () => {
                           className="mt-0.5 text-[18px]"
                         />
                       </button>
-                      <img
-                        src={item.metadata?.favicon}
-                        alt="favicon"
-                        width={12}
-                        height={12}
-                        className="mt-0.5 size-4 shrink-0"
-                      />
                       <p className="mr-1">{item.title}</p>
                       <div className="flex items-center gap-2 text-xs text-secondary-foreground">
+                        {item.metadata?.favicon ? (
+                          <ImageWithFallback
+                            src={item.metadata?.favicon}
+                            alt=""
+                            width={12}
+                            height={12}
+                            className=" size-4 shrink-0"
+                          />
+                        ) : (
+                          ""
+                        )}
                         <button className="invisible focus:outline-none focus:ring-0 group-hover:visible">
                           <Icon
                             icon="humbleicons:clock"

--- a/apps/frontend/src/components/Inbox/InboxItems.tsx
+++ b/apps/frontend/src/components/Inbox/InboxItems.tsx
@@ -186,6 +186,9 @@ export const InboxItems: React.FC = () => {
                           className="mt-0.5 text-[18px]"
                         />
                       </button>
+                      <span className="mt-1.5 size-2 rounded bg-white">
+                        {item.metadata?.favicon}
+                      </span>
                       <p className="mr-1">{item.title}</p>
                       <div className="flex items-center gap-2 text-xs text-secondary-foreground">
                         <button className="invisible focus:outline-none focus:ring-0 group-hover:visible">

--- a/apps/frontend/src/components/Inbox/InboxItems.tsx
+++ b/apps/frontend/src/components/Inbox/InboxItems.tsx
@@ -190,9 +190,9 @@ export const InboxItems: React.FC = () => {
                       <img
                         src={item.metadata?.favicon}
                         alt="favicon"
-                        width={16}
-                        height={16}
-                        className="size-5 shrink-0"
+                        width={12}
+                        height={12}
+                        className="mt-0.5 size-4 shrink-0"
                       />
                       <p className="mr-1">{item.title}</p>
                       <div className="flex items-center gap-2 text-xs text-secondary-foreground">

--- a/apps/frontend/src/lib/@types/Items/Cycle.ts
+++ b/apps/frontend/src/lib/@types/Items/Cycle.ts
@@ -11,8 +11,8 @@ export interface CycleItem {
   blocks: string[]
   labels: string[]
   metadata?: {
-    url: string
-    favicon: string
+    url?: string
+    favicon?: string
   }
   isCompleted: boolean
   isArchived: boolean

--- a/apps/frontend/src/lib/@types/Items/Cycle.ts
+++ b/apps/frontend/src/lib/@types/Items/Cycle.ts
@@ -10,8 +10,9 @@ export interface CycleItem {
   spaces: string[]
   blocks: string[]
   labels: string[]
-  metadata: {
+  metadata?: {
     url: string
+    favicon: string
   }
   isCompleted: boolean
   isArchived: boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a favicon display for each item in the inbox, enhancing visual representation.
	- Improved item title handling with URL validation and formatting when adding items to the inbox.
	- Enhanced the Custom Kanban interface with improved item submission logic and visual cues.
	- Streamlined the rendering process of the AddToSpace component by removing the loading state check for spaces.

- **Bug Fixes**
	- Updated functionality to toggle item status between "done" and "null," with improved state management for accurate toggling.

- **Documentation**
	- Updated type definitions to make the `metadata` property optional and include a new `favicon` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->