### PR TITLE
fix MAR-277-shorten item title in today board

### DIFF
--- a/apps/frontend/src/components/DropDownItems.tsx
+++ b/apps/frontend/src/components/DropDownItems.tsx
@@ -1,7 +1,4 @@
-import { format } from "path"
-
 import React from "react"
-
 import { Icon } from "@iconify-icon/react/dist/iconify.mjs"
 
 import { AddToSpace } from "./AddToSpace"
@@ -24,7 +21,7 @@ export interface DropdownItemProps {
   maxTitleLength?: number
 }
 
-const getSourceIcon = (source) => {
+const getSourceIcon = (source: string) => {
   switch (source) {
     case "github":
       return (
@@ -51,29 +48,22 @@ const getSourceIcon = (source) => {
   }
 }
 
-export interface DropdownItemProps {
-  item: CycleItem
-  onToggleComplete: (item: CycleItem) => void
-  isOverdue?: boolean
-  maxTitleLength?: number
-}
-
 export const DropdownItem: React.FC<DropdownItemProps> = ({
   item,
   onToggleComplete,
   isOverdue,
-  maxTitleLength = 25,  // Changed to 25 characters
+  maxTitleLength = 25,
 }) => {
   const truncateTitle = (title: string) => {
-    if (!maxTitleLength || title.length <= maxTitleLength) return title;
-    return `${title.slice(0, maxTitleLength)}...`;
-  };
+    if (!maxTitleLength || title.length <= maxTitleLength) return title
+    return `${title.slice(0, maxTitleLength)}...`
+  }
 
   const titleElement = (
     <span className="truncate">
       {truncateTitle(item.title)}
     </span>
-  );
+  )
 
   return (
     <div className="group relative flex items-center gap-2">

--- a/apps/frontend/src/components/DropDownItems.tsx
+++ b/apps/frontend/src/components/DropDownItems.tsx
@@ -56,7 +56,7 @@ export const DropdownItem: React.FC<DropdownItemProps> = ({
 }) => {
   const truncateTitle = (title: string) => {
     if (!maxTitleLength || title.length <= maxTitleLength) return title
-    return `${title.slice(0, maxTitleLength)}...`
+    return `${title.slice(0, maxTitleLength)}…`  // Using proper ellipsis character
   }
 
   const titleElement = (
@@ -71,7 +71,9 @@ export const DropdownItem: React.FC<DropdownItemProps> = ({
         {item.status === "done" ? <CheckedBox /> : <Box />}
       </button>
       <li
-        className={`${item.isCompleted ? "text-[#6D7077]" : "text-white"} flex min-w-0 items-center gap-2`}
+        className={`${
+          item.isCompleted ? "text-[#6D7077]" : "text-white"
+        } flex min-w-0 items-center gap-2`}
       >
         {item.metadata?.url ? (
           <a
@@ -92,7 +94,7 @@ export const DropdownItem: React.FC<DropdownItemProps> = ({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <span className="inline-block size-2 shrink-0 rounded-full bg-[#E34136]/80"></span>
+                <span className="inline-block size-2 shrink-0 rounded-full bg-[#E34136]/80" />
               </TooltipTrigger>
               <TooltipContent>
                 {getOverdueText(item.dueDate) ?? ""}

--- a/apps/frontend/src/components/DropDownItems.tsx
+++ b/apps/frontend/src/components/DropDownItems.tsx
@@ -17,10 +17,11 @@ import { LinearDark } from "../lib/icons/LinearCircle"
 import { Link } from "../lib/icons/Link"
 import { getOverdueText } from "../utils/datetime"
 
-interface DropdownItemProps {
+export interface DropdownItemProps {
   item: CycleItem
   onToggleComplete: (item: CycleItem) => void
   isOverdue?: boolean
+  maxTitleLength?: number
 }
 
 const getSourceIcon = (source) => {
@@ -50,11 +51,30 @@ const getSourceIcon = (source) => {
   }
 }
 
+export interface DropdownItemProps {
+  item: CycleItem
+  onToggleComplete: (item: CycleItem) => void
+  isOverdue?: boolean
+  maxTitleLength?: number
+}
+
 export const DropdownItem: React.FC<DropdownItemProps> = ({
   item,
   onToggleComplete,
   isOverdue,
+  maxTitleLength = 25,  // Changed to 25 characters
 }) => {
+  const truncateTitle = (title: string) => {
+    if (!maxTitleLength || title.length <= maxTitleLength) return title;
+    return `${title.slice(0, maxTitleLength)}...`;
+  };
+
+  const titleElement = (
+    <span className="truncate">
+      {truncateTitle(item.title)}
+    </span>
+  );
+
   return (
     <div className="group relative flex items-center gap-2">
       <button onClick={() => onToggleComplete(item)}>
@@ -70,13 +90,13 @@ export const DropdownItem: React.FC<DropdownItemProps> = ({
             rel="noopener noreferrer"
             className="flex items-center gap-3 truncate"
           >
-            <span className="truncate">{item.title}</span>
+            {titleElement}
             <span className="shrink-0">
               {getSourceIcon(item.source) || <Link />}
             </span>
           </a>
         ) : (
-          <span className="truncate">{item.title}</span>
+          titleElement
         )}
         {isOverdue && (
           <TooltipProvider>

--- a/apps/frontend/src/components/TodayItems.tsx
+++ b/apps/frontend/src/components/TodayItems.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from "react"
 
 import { SkeletonCard } from "./atoms/SkeletonCard"
-import { DropdownItem } from "./DropDownItems"
+import { DropdownItem, DropdownItemProps } from "./DropDownItems"
 import { useAuth } from "../contexts/AuthContext"
 import { CycleItem } from "../lib/@types/Items/Cycle"
 import { useCycleItemStore } from "../lib/store/cycle.store"
@@ -76,6 +76,7 @@ export const TodayItems: React.FC<TodayEventsProps> = ({
                 item={item}
                 onToggleComplete={(item) => handleToggleComplete(item)}
                 isOverdue={false}
+                maxTitleLength={50}
               />
             </React.Fragment>
           ))}
@@ -89,6 +90,7 @@ export const TodayItems: React.FC<TodayEventsProps> = ({
                 item={item}
                 onToggleComplete={(item) => handleToggleComplete(item)}
                 isOverdue={true}
+                maxTitleLength={50}
               />
             </React.Fragment>
           ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable `maxTitleLength` for dropdown item titles, enhancing display management for long titles.
	- Titles will now be truncated with an ellipsis if they exceed the specified length.

- **Bug Fixes**
	- Clarified error handling in the `TodayItems` component, improving overall error management.

- **Documentation**
	- Updated import statements to reflect changes in props for better clarity and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->