### PR TITLE
fix: editor content size

### DIFF
--- a/apps/frontend/src/components/Notes/NotesPage.tsx
+++ b/apps/frontend/src/components/Notes/NotesPage.tsx
@@ -4,7 +4,6 @@ import { useState, useRef, useEffect, useCallback } from "react"
 
 import { Icon } from "@iconify-icon/react/dist/iconify.mjs"
 import { PlusIcon } from "@radix-ui/react-icons"
-import { format } from "date-fns"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 

--- a/apps/frontend/src/components/Notes/NotesPage.tsx
+++ b/apps/frontend/src/components/Notes/NotesPage.tsx
@@ -291,7 +291,7 @@ const NotesPage: React.FC<Props> = ({ noteId }) => {
               onFocus={() => setIsEditingTitle(true)}
               onBlur={() => setIsEditingTitle(false)}
             />
-            <div className="text-foreground">
+            <div className="max-w-6xl text-foreground">
               <TextEditor editor={editor} />
             </div>
           </div>

--- a/apps/frontend/src/styles/tiptap.css
+++ b/apps/frontend/src/styles/tiptap.css
@@ -57,11 +57,11 @@
 
     li {
       display: flex;
-      align-items: center;
+      align-items: start;
       /* Add some padding for spacing between list items */
 
       >label {
-        @apply flex items-center mr-2 mt-2.5;
+        @apply flex items-center mr-2 mt-1.5;
       }
 
       >div {
@@ -80,7 +80,7 @@
   }
 
   ol {
-    @apply list-decimal ml-4;
+    @apply list-decimal ml-6 pl-4;
   }
 
   blockquote {


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->
- [x] fixed editor content area, expand/collapse on notes stack wont' change the editor size
**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.

