### PR TITLE
feat: create hook with logic for contextual create

### DIFF
--- a/apps/frontend/src/hooks/useContextualCreate.tsx
+++ b/apps/frontend/src/hooks/useContextualCreate.tsx
@@ -1,0 +1,70 @@
+import { useState, useCallback, useEffect } from "react"
+
+interface ContextualCreateState {
+  isOpen: boolean
+  context: "inbox" | "thisWeek" | "readingList" | null
+  inputText: string
+  position: { x: number; y: number }
+}
+
+export const useContextualCreate = () => {
+  const [state, setState] = useState<ContextualCreateState>({
+    isOpen: false,
+    context: null,
+    inputText: "",
+    position: { x: 0, y: 0 },
+  })
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Command+C (Mac) or Control+C (Windows)
+      if ((e.metaKey || e.ctrlKey) && e.key === "c") {
+        e.preventDefault()
+        // Get selected text
+        const selectedText = window.getSelection()?.toString() || ""
+
+        // Get cursor position or selection position
+        const selection = window.getSelection()
+        if (selection && selection.rangeCount > 0) {
+          const range = selection.getRangeAt(0)
+          const rect = range.getBoundingClientRect()
+
+          // Determine context based on where the cursor is
+          const context = determineContext()
+
+          setState({
+            isOpen: true,
+            context,
+            inputText: selectedText,
+            position: {
+              x: rect.left,
+              y: rect.bottom + window.scrollY,
+            },
+          })
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [])
+
+  const determineContext = (): "inbox" | "thisWeek" | "readingList" => {
+    // Check URL path
+    const path = window.location.pathname
+    if (path.includes("inbox")) return "inbox"
+    if (path.includes("this-week")) return "thisWeek"
+    if (path.includes("space/reading-list")) return "readingList"
+
+    return "inbox"
+  }
+
+  const closeContextualCreate = useCallback(() => {
+    setState((prev) => ({ ...prev, isOpen: false }))
+  }, [])
+
+  return {
+    ...state,
+    closeContextualCreate,
+  }
+}


### PR DESCRIPTION
# What did you ship?

Currently implementing a context-aware creation system triggered by Command+C (Mac) or Ctrl+C (Windows). More simply, this feature creates different types of items based on where you are in the application by showing a contextual menu with relevant options for quick creation.

**Fixes:**

- [x] #234 (GitHub issue number)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [x] shut up and let me cook. :))

