### PR TITLE
fix: removed feedback shortcut

### DIFF
--- a/apps/frontend/src/app/(app)/providers.tsx
+++ b/apps/frontend/src/app/(app)/providers.tsx
@@ -6,7 +6,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import { AuthProvider } from "@/src/contexts/AuthContext"
-import ModalProvider from "@/src/contexts/ModalProvider"
 import { WebSocketProvider } from "@/src/contexts/WebsocketProvider"
 
 interface ProvidersProps {
@@ -30,9 +29,7 @@ export function Providers({ children, initialData }: ProvidersProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <WebSocketProvider>
-          <ModalProvider>{children}</ModalProvider>
-        </WebSocketProvider>
+        <WebSocketProvider>{children}</WebSocketProvider>
       </AuthProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/apps/frontend/src/contexts/ModalProvider.tsx
+++ b/apps/frontend/src/contexts/ModalProvider.tsx
@@ -34,21 +34,21 @@ const ModalProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const hideModal = () => setIsModalVisible(false)
 
   // Load specific modals on keypress
-  const handleKeyPress = (event: KeyboardEvent) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === "f") {
-      event.preventDefault()
-      showModal(<FeedbackModal />)
-    }
-  }
+  //  const handleKeyPress = (event: KeyboardEvent) => {
+  //    if ((event.metaKey || event.ctrlKey) && event.key === "f") {
+  //      event.preventDefault()
+  //      showModal(<FeedbackModal />)
+  //    }
+  //  }
 
-  useEffect(() => {
-    console.log("Keypress listener activated")
-    window.addEventListener("keydown", handleKeyPress)
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyPress)
-    }
-  }, [])
+  //  useEffect(() => {
+  //    console.log("Keypress listener activated")
+  //    window.addEventListener("keydown", handleKeyPress)
+  //
+  //    return () => {
+  //      window.removeEventListener("keydown", handleKeyPress)
+  //    }
+  //  }, [])
 
   return (
     <ModalContext.Provider value={{ showModal, hideModal }}>


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `ModalProvider` and comment out feedback shortcut logic, disabling feedback modal functionality.
> 
>   - **Behavior**:
>     - Removed `ModalProvider` from `Providers` in `providers.tsx`, disabling feedback modal functionality.
>     - Commented out feedback shortcut logic in `ModalProvider.tsx`, preventing modal from opening on keypress.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for a9c247baff17f5d82cd5c1a8ae348ff2796775ab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->