### PR TITLE
fix: get event of selected date on cal

### DIFF
--- a/apps/frontend/src/components/blocks/calendar/cal.tsx
+++ b/apps/frontend/src/components/blocks/calendar/cal.tsx
@@ -14,9 +14,7 @@ import { formatEventDate } from "@/src/utils/datetime"
 function CalendarBlock() {
   const { session } = useAuth()
 
-  const { calendar } = useCalendar()
-  const calendarRef = useRef<HTMLDivElement>(null)
-  const date = new Date().toISOString().split("T")[0]
+  const { calendar, selectedDate, calendarRef } = useCalendar()
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
@@ -42,7 +40,7 @@ function CalendarBlock() {
     }
   }, [])
 
-  const { data: events, isLoading, error } = useEvents(session, date)
+  const { data: events, isLoading, error } = useEvents(session, selectedDate)
 
   useEffect(() => {
     if (Array.isArray(events)) {

--- a/apps/frontend/src/hooks/useCalendar.hook.ts
+++ b/apps/frontend/src/hooks/useCalendar.hook.ts
@@ -1,3 +1,5 @@
+import { useRef, useState } from "react"
+
 import {
   CalendarEvent,
   createViewDay,
@@ -25,13 +27,17 @@ const useCalendar = ({
   defaultView = viewDay.name,
   theme = "shadcn",
 }: UseCalendarProps = {}) => {
+  const calendarRef = useRef<HTMLDivElement>(null)
+  const [selectedDate, setSelectedDate] = useState<string>("")
+  const calendarControls = createCalendarControlsPlugin()
+
   const plugins = [
     createDragAndDropPlugin(),
     createResizePlugin(),
     createCurrentTimePlugin(),
     createEventModalPlugin(),
     createEventsServicePlugin(),
-    createCalendarControlsPlugin(),
+    calendarControls,
   ]
 
   const calendar = useNextCalendarApp(
@@ -45,12 +51,26 @@ const useCalendar = ({
       ],
       events,
       theme,
+      callbacks: {
+        onRender($app) {
+          const date = calendarControls.getDate()
+          console.log("Calendar initialized with date:", date)
+        },
+        onSelectedDateUpdate($app) {
+          const newDate = calendarControls.getDate()
+          setSelectedDate(newDate)
+          console.log("Date changed to:", newDate)
+        },
+      },
     },
     plugins
   )
 
   return {
     calendar,
+    calendarControls,
+    calendarRef,
+    selectedDate,
   }
 }
 


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `CalendarBlock` to use `selectedDate` from `useCalendar` for event fetching, enhancing date management.
> 
>   - **Behavior**:
>     - `CalendarBlock` now uses `selectedDate` from `useCalendar` instead of a hardcoded date for fetching events.
>     - `useCalendar` hook now manages `selectedDate` state and updates it via `calendarControls` plugin callbacks.
>   - **Hooks**:
>     - `useCalendar` adds `selectedDate` state and `calendarRef` using `useRef`.
>     - Adds `onRender` and `onSelectedDateUpdate` callbacks to update `selectedDate` in `useCalendar`.
>   - **Components**:
>     - `CalendarBlock` component updated to use `selectedDate` for `useEvents` query.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=emptyarrayhq%2Femptyarray&utm_source=github&utm_medium=referral)<sup> for c34f3182f56ce92b99d9f17e31b4ff5ea1e69d69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->