### PR TITLE
fix: inbox data fetch

### DIFF
--- a/apps/web/src/components/blocks/list/list-items.tsx
+++ b/apps/web/src/components/blocks/list/list-items.tsx
@@ -101,7 +101,7 @@ export function ListItems() {
                     </div>
                   </SheetTrigger>
                   <span onClick={(e) => e.stopPropagation()}>
-                    <a href={item.metadata.url} target="_blank">
+                    <a href={item.metadata?.url} target="_blank">
                       {renderIcon(item.source)}
                     </a>
                   </span>{" "}


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.

### Description
This pull request addresses an issue with inbox data fetching. The main change is in the file `apps/web/src/components/blocks/list/list-items.tsx`, where a potential null or undefined value for `item.metadata.url` is handled more safely.

The modification involves changing:
```typescript
<a href={item.metadata.url} target="_blank">
```
to:
```typescript
<a href={item.metadata?.url} target="_blank">
```

This change uses the optional chaining operator (`?.`) to safely access the `url` property of `item.metadata`, preventing potential runtime errors if `metadata` is null or undefined.

### Test
N/A

### Changes that Break Backward Compatibility
N/A

### Documentation
N/A

*Created with [Palmier](https://www.palmier.io)*