### PR TITLE
ui: show inline time for events with small duration

### DIFF
--- a/apps/web/src/components/blocks/calendar/event-content.tsx
+++ b/apps/web/src/components/blocks/calendar/event-content.tsx
@@ -9,6 +9,26 @@ export function renderEventContent(eventInfo: any) {
     borderLeft: `4px solid ${EVENT_COLORS[colorId].borderColor}`,
   };
 
+  // Calculate event duration in minutes
+  const start = eventInfo.event.start;
+  const end = eventInfo.event.end;
+  const durationInMinutes = end
+    ? (end.getTime() - start.getTime()) / (1000 * 60)
+    : 0;
+
+  const startText = eventInfo.timeText.split(" - ")[0];
+
+  if (durationInMinutes <= 30) {
+    return (
+      <div className="custom-event-content pl-2" style={style}>
+        <div className="flex items-center gap-2">
+          <span className="fc-event-title">{eventInfo.event.title}</span>
+          <span className="fc-event-time text-sm">{startText}</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="custom-event-content pl-2" style={style}>
       <div className="fc-event-title">{eventInfo.event.title}</div>


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `renderEventContent()` to display start time inline for events with duration <= 30 minutes in `event-content.tsx`.
> 
>   - **Behavior**:
>     - In `renderEventContent()` in `event-content.tsx`, events with duration <= 30 minutes now display start time inline with the title.
>     - For events > 30 minutes, the full time range is displayed as before.
>   - **UI**:
>     - Adds a conditional check for event duration to determine rendering style.
>     - Uses `startText` for short events to show only the start time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for f8cc5057130150b213dbd7dc87cf178317a8fafa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->