### PR TITLE
fix: two event creation on drag to cal

### DIFF
--- a/apps/web/src/components/blocks/list/list-items.tsx
+++ b/apps/web/src/components/blocks/list/list-items.tsx
@@ -14,7 +14,11 @@ import { Sheet, SheetTrigger } from "@/components/ui/sheet";
 import ExpandedView from "@/components/object/expanded-view";
 import { Icons } from "@/components/ui/icons";
 
-export function ListItems() {
+interface ListItemsProps {
+  onDragStateChange?: (isDragging: boolean) => void;
+}
+
+export function ListItems({ onDragStateChange }: ListItemsProps) {
   const { items } = useBlock();
 
   const { mutate: updateObject } = useUpdateObject();
@@ -68,6 +72,7 @@ export function ListItems() {
               checked: item.isCompleted,
             }}
             index={index}
+            onDragStateChange={onDragStateChange}
           >
             <div className="flex items-center w-full py-2 px-1 rounded-md hover:bg-gray-50 transition-colors group">
               <div className="flex items-center gap-2 w-full">

--- a/apps/web/src/components/blocks/list/list.tsx
+++ b/apps/web/src/components/blocks/list/list.tsx
@@ -5,6 +5,7 @@ import { ListItems } from "./list-items";
 import { BlockProvider } from "@/contexts/block-context";
 import { useCreateObject } from "@/hooks/use-objects";
 import { CreateObject } from "@/types/objects";
+import { useState } from "react";
 
 interface Props {
   header?: string;
@@ -13,13 +14,14 @@ interface Props {
 
 export default function ListBlock({ arrayType }: Props) {
   const { mutate: createObject } = useCreateObject();
+  const [isDragging, setIsDragging] = useState(false);
 
   const handleSubmit = (data: CreateObject) => {
     createObject(data);
   };
 
   return (
-    <div className="w-full mx-auto">
+    <div className={`w-full mx-auto ${isDragging ? "overflow-hidden" : ""}`}>
       <BlockProvider arrayType={arrayType}>
         <section className="space-y-3 px-4 pt-2">
           <InputBox
@@ -30,7 +32,7 @@ export default function ListBlock({ arrayType }: Props) {
         </section>
         <section className="pt-3 px-4">
           <div className="draggable-container">
-            <ListItems />
+            <ListItems onDragStateChange={setIsDragging} />
           </div>
         </section>
       </BlockProvider>

--- a/apps/web/src/components/blocks/list/sortable-item.tsx
+++ b/apps/web/src/components/blocks/list/sortable-item.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { SortableObject } from "@/types/objects";
+import { useEffect } from "react";
 
 interface SortableItemProps {
   id: string | number;
@@ -14,6 +15,7 @@ interface SortableItemProps {
   };
   containerId: string;
   index: number;
+  onDragStateChange?: (isDragging: boolean) => void;
 }
 
 export function SortableItem({
@@ -23,6 +25,7 @@ export function SortableItem({
   item,
   containerId,
   index,
+  onDragStateChange,
 }: SortableItemProps) {
   const {
     attributes,
@@ -36,6 +39,10 @@ export function SortableItem({
     data: data,
     disabled: document.querySelector('[role="dialog"]') !== null,
   });
+
+  useEffect(() => {
+    onDragStateChange?.(isDragging);
+  }, [isDragging, onDragStateChange]);
 
   const isEditorFocused = (event: KeyboardEvent | React.MouseEvent) => {
     const target = event.target as HTMLElement;

--- a/apps/web/src/contexts/block-context.tsx
+++ b/apps/web/src/contexts/block-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, ReactNode } from "react";
+import { createContext, useContext, ReactNode, useRef } from "react";
 import { DragEndEvent } from "@dnd-kit/core";
 import { CalendarEvent, Event } from "@/types/calendar";
 import { arrayMove } from "@dnd-kit/sortable";
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/use-objects";
 import { useEvents } from "@/hooks/use-events";
 import moment from "moment";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface BlockContextType {
   items: Objects[];
@@ -35,11 +36,15 @@ export function BlockProvider({ children, arrayType }: BlockProviderProps) {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const query = arrayType === "inbox" ? useInboxObjects() : useTodayObjects();
   const { mutate: updateOrder } = useOrderObject();
+  const queryClient = useQueryClient();
 
   const { data: items = [], isLoading, error } = query;
 
   const today = moment().format("YYYY-MM-DD");
   const { data: events = [], addEvent, delEvent } = useEvents(today);
+
+  // Add a ref to track if calendar drop is being handled
+  const isHandlingCalendarDrop = useRef(false);
 
   const handleInternalListSort = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -51,7 +56,7 @@ export function BlockProvider({ children, arrayType }: BlockProviderProps) {
     const isCalendarDrop = over.id === "calendar-drop-area";
 
     // Skip if this is a calendar drop
-    if (isCalendarDrop) return;
+    if (isCalendarDrop || isHandlingCalendarDrop.current) return;
 
     if (isActiveListItem && isOverListItem) {
       const activeId = active.id as string;
@@ -78,44 +83,68 @@ export function BlockProvider({ children, arrayType }: BlockProviderProps) {
   };
 
   const handleCalendarDrop = (draggedItem: SortableObject, dropDate?: Date) => {
-    console.log("HandleCalendarDrop Called:", {
-      draggedItem,
-      dropDate,
-      dropDateISO: dropDate?.toISOString(),
-    });
+    if (isHandlingCalendarDrop.current) return;
+    if (!draggedItem || !dropDate) {
+      console.error("Missing required data for calendar drop");
+      return;
+    }
 
-    if (!draggedItem) return;
+    try {
+      isHandlingCalendarDrop.current = true;
 
-    // Use provided dropDate or current time as fallback
-    const startDate = dropDate || new Date();
-    const endDate = new Date(startDate.getTime() + 60 * 60 * 1000); // 1 hour duration
+      const startDate = dropDate;
+      const endDate = new Date(startDate.getTime() + 60 * 60 * 1000);
 
-    console.log("Creating New Event:", {
-      startDate,
-      startDateISO: startDate.toISOString(),
-      endDate,
-      endDateISO: endDate.toISOString(),
-      summary: draggedItem.text,
-    });
+      const newEvent: Partial<Event> = {
+        summary: draggedItem.text || "New Event",
+        start: {
+          dateTime: startDate.toISOString(),
+        },
+        end: {
+          dateTime: endDate.toISOString(),
+        },
+      };
 
-    const newEvent: Partial<Event> = {
-      summary: draggedItem.text || "New Event",
-      start: {
-        dateTime: startDate.toISOString(),
-      },
-      end: {
-        dateTime: endDate.toISOString(),
-      },
-    };
+      // Create the calendar event
+      addEvent(newEvent);
 
-    addEvent(newEvent);
+      // Immediately update the cache to reflect the change
+      if (
+        draggedItem.sortable &&
+        draggedItem.sortable.items &&
+        draggedItem.sortable.items.length > 0
+      ) {
+        const itemId = draggedItem.sortable.items[0];
+
+        // Update the cache directly
+        const queryKey =
+          arrayType === "inbox" ? ["inbox-objects"] : ["today-objects"];
+        queryClient.setQueryData(queryKey, (oldData: Objects[] = []) => {
+          return oldData.map((item) =>
+            item._id === itemId ? { ...item, isCompleted: true } : item
+          );
+        });
+
+        // Also invalidate to ensure we get fresh data
+        queryClient.invalidateQueries({ queryKey: ["inbox-objects"] });
+        queryClient.invalidateQueries({ queryKey: ["today-objects"] });
+      }
+    } finally {
+      // Reset the flag after a short delay to ensure all handlers have completed
+      setTimeout(() => {
+        isHandlingCalendarDrop.current = false;
+      }, 100);
+    }
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { over } = event;
     if (!over) return;
 
-    // Only handle internal list sorting, ignore calendar drops completely
+    // Skip if we're handling a calendar drop
+    if (isHandlingCalendarDrop.current) return;
+
+    // Only handle internal list sorting
     handleInternalListSort(event);
   };
 

--- a/apps/web/src/contexts/block-context.tsx
+++ b/apps/web/src/contexts/block-context.tsx
@@ -109,12 +109,8 @@ export function BlockProvider({ children, arrayType }: BlockProviderProps) {
       addEvent(newEvent);
 
       // Immediately update the cache to reflect the change
-      if (
-        draggedItem.sortable &&
-        draggedItem.sortable.items &&
-        draggedItem.sortable.items.length > 0
-      ) {
-        const itemId = draggedItem.sortable.items[0];
+      if (draggedItem.id && typeof draggedItem.id === "string") {
+        const itemId = draggedItem.id;
 
         // Update the cache directly
         const queryKey =

--- a/apps/web/src/types/objects.ts
+++ b/apps/web/src/types/objects.ts
@@ -79,6 +79,7 @@ interface OrderObjectRequest {
 }
 
 interface SortableObject {
+  id?: string;
   type: string;
   text: string;
   checked: boolean;


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes double event creation on calendar drag by adding flags to manage drag state and updating cache immediately.
> 
>   - **Behavior**:
>     - Fixes double event creation on drag to calendar in `calendar.tsx` by using `isProcessingDrop` flag.
>     - Updates cache immediately after event creation in `block-context.tsx` to reflect changes.
>   - **Drag-and-Drop**:
>     - Adds `onDragStateChange` prop to `ListItems` and `SortableItem` to manage drag state.
>     - Uses `isHandlingCalendarDrop` in `block-context.tsx` to prevent concurrent calendar drop handling.
>   - **Misc**:
>     - Adds `id` to `SortableObject` in `objects.ts` for better identification.
>     - Minor UI adjustments in `list.tsx` to handle drag state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for 319c38af942abceabf43f74fe9b4f72b9196aea2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->