### PR TITLE
fix: event url

### DIFF
--- a/apps/web/src/components/blocks/calendar/event-details.tsx
+++ b/apps/web/src/components/blocks/calendar/event-details.tsx
@@ -102,34 +102,36 @@ const EventDetails = ({
               </p>
             </div>
             <div className="mt-2">
-              {selectedEvent.event.extendedProps?.meetingUrl && (
-                <a
-                  href={selectedEvent.event.extendedProps.meetingUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 text-xs text-gray-400 hover:underline"
-                >
-                  {selectedEvent.event.extendedProps.meetingIconUrl ? (
-                    <Image
-                      src={selectedEvent.event.extendedProps.meetingIconUrl}
-                      alt="Meeting platform icon"
-                      width={16}
-                      height={16}
-                    />
-                  ) : (
-                    <Link className="size-4" />
-                  )}
-                  {selectedEvent.event.extendedProps.meetingUrl?.includes(
-                    "meet"
-                  )
-                    ? "Join with Meet"
-                    : selectedEvent.event.extendedProps.meetingUrl?.includes(
-                          "zoom"
-                        )
-                      ? "Join with Zoom"
-                      : "Join"}
-                </a>
-              )}
+              {selectedEvent.event.extendedProps?.meetingUrl &&
+                (selectedEvent.event.extendedProps.meetingUrl.includes(
+                  "meet"
+                ) ||
+                  selectedEvent.event.extendedProps.meetingUrl.includes(
+                    "zoom"
+                  )) && (
+                  <a
+                    href={selectedEvent.event.extendedProps.meetingUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-xs text-gray-400 hover:underline"
+                  >
+                    {selectedEvent.event.extendedProps.meetingIconUrl ? (
+                      <Image
+                        src={selectedEvent.event.extendedProps.meetingIconUrl}
+                        alt="Meeting platform icon"
+                        width={16}
+                        height={16}
+                      />
+                    ) : (
+                      <Link className="size-4" />
+                    )}
+                    {selectedEvent.event.extendedProps.meetingUrl?.includes(
+                      "meet"
+                    )
+                      ? "Join with Meet"
+                      : "Join with Zoom"}
+                  </a>
+                )}
             </div>
           </div>
         </PopoverContent>


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**
- [x] will not show any event url

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts event URL display in `event-details.tsx` to only 'meet' or 'zoom' links, removing generic 'Join' text.
> 
>   - **Behavior**:
>     - In `event-details.tsx`, restricts event URL display to URLs containing 'meet' or 'zoom'.
>     - Removes generic 'Join' link text, now only shows 'Join with Meet' or 'Join with Zoom'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for 7486781973c58b178110d00edbdab2d6f16ce282. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->