### PR TITLE
feat: blue dots on notes under date

### DIFF
--- a/apps/web/src/components/blocks/daily-notes/daily-notes.tsx
+++ b/apps/web/src/components/blocks/daily-notes/daily-notes.tsx
@@ -27,10 +27,11 @@ interface JournalResponse {
 interface CalendarGridProps {
   currentDate: Date;
   onSelectDate: (date: Date) => void;
+  datesWithEntries: string[];
 }
 
 // Calendar grid component to display days of the month
-function CalendarGrid({ currentDate, onSelectDate }: CalendarGridProps) {
+function CalendarGrid({ currentDate, onSelectDate, datesWithEntries }: CalendarGridProps) {
   // Get the first day of the month
   const firstDayOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
   // Get the last day of the month
@@ -94,13 +95,16 @@ function CalendarGrid({ currentDate, onSelectDate }: CalendarGridProps) {
           key={index}
           onClick={() => onSelectDate(day.date)}
           className={`
-            w-10 h-10 flex items-center justify-center text-sm
+            w-10 h-10 flex flex-col items-center justify-center text-sm relative
             ${day.isCurrentMonth ? 'text-gray-900' : 'text-gray-400'}
             ${day.isToday ? 'font-bold text-blue-600' : 'hover:bg-gray-100'}
             ${format(currentDate, 'yyyy-MM-dd') === format(day.date, 'yyyy-MM-dd') ? 'bg-blue-500 text-white rounded-full' : ''}
           `}
         >
           {day.dayOfMonth}
+          {datesWithEntries.includes(format(day.date, 'yyyy-MM-dd')) && (
+            <div className="absolute bottom-0.5 w-2 h-2 bg-blue-500 rounded-full"></div>
+          )}
         </button>
       ))}
     </div>
@@ -130,6 +134,10 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
   // Initialize state with null, will be populated in useEffect
   const [content, setContent] = useState<JSONContent | null>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  
+  // Track dates with journal entries
+  const [datesWithEntries, setDatesWithEntries] = useState<string[]>([]);
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
 
   // Reference for the save timeout
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -151,6 +159,59 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
   // Navigate to today
   const goToToday = () => {
     setCurrentDate(new Date());
+  };
+  
+  // Fetch dates with journal entries
+  const fetchDatesWithEntries = async () => {
+    try {
+      // Get the current month and year for filtering
+      const year = currentDate.getFullYear();
+      const month = currentDate.getMonth() + 1; // JavaScript months are 0-indexed
+      
+      // Try to fetch from API first
+      try {
+        const response = await apiClient.get('/api/journals/dates', {
+          params: { year, month }
+        });
+        
+        if (response.dates && Array.isArray(response.dates)) {
+          setDatesWithEntries(response.dates);
+          return;
+        }
+      } catch (apiError) {
+        console.log("API endpoint for journal dates not available, using localStorage");
+      }
+      
+      // Fallback to checking localStorage
+      const dates = [];
+      // Get all localStorage keys
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        // Check if it's a daily notes entry
+        if (key && key.startsWith('daily-notes-')) {
+          const dateStr = key.replace('daily-notes-', '');
+          // Check if the date is valid and in the current month/year
+          try {
+            const entryDate = new Date(dateStr);
+            if (
+              entryDate.getFullYear() === year &&
+              entryDate.getMonth() === month - 1
+            ) {
+              dates.push(dateStr);
+            }
+          } catch (e) {
+            // Skip invalid dates
+          }
+        }
+      }
+      
+      console.log("Found dates with entries:", dates);
+      setDatesWithEntries(dates);
+    } catch (error) {
+      console.error('Error fetching dates with entries:', error);
+      // Fallback to empty array if both API and localStorage checks fail
+      setDatesWithEntries([]);
+    }
   };
 
   // Load content from API or localStorage
@@ -263,8 +324,13 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
     // Load content for the new date
     loadContent();
     
+    // If calendar is open, refresh the dates with entries
+    if (isCalendarOpen) {
+      fetchDatesWithEntries();
+    }
+    
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentDate]);
+  }, [currentDate, isCalendarOpen]);
   
   // Initial setup and cleanup
   useEffect(() => {
@@ -290,7 +356,13 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
   return (
     <div className="daily-notes bg-white p-6 mb-6">
       <div className="flex justify-between items-center mb-4">
-        <Popover.Root>
+        <Popover.Root onOpenChange={(open) => {
+            setIsCalendarOpen(open);
+            if (open) {
+              // Fetch dates with entries when calendar opens
+              setTimeout(() => fetchDatesWithEntries(), 0);
+            }
+          }}>
           <Popover.Trigger asChild>
             <button 
               className="flex items-center text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 px-2 py-1 rounded-md transition-colors"
@@ -400,6 +472,7 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
                 
                 <CalendarGrid 
                   currentDate={currentDate} 
+                  datesWithEntries={datesWithEntries}
                   onSelectDate={(date) => {
                     setCurrentDate(date);
                     // Close the popover after selection

--- a/apps/web/src/components/blocks/daily-notes/daily-notes.tsx
+++ b/apps/web/src/components/blocks/daily-notes/daily-notes.tsx
@@ -24,6 +24,10 @@ interface JournalResponse {
   };
 }
 
+interface JournalDatesResponse {
+  dates: string[];
+}
+
 interface CalendarGridProps {
   currentDate: Date;
   onSelectDate: (date: Date) => void;
@@ -170,11 +174,10 @@ export function DailyNotes({ date: initialDate = new Date() }: DailyNotesProps) 
       
       // Try to fetch from API first
       try {
-        const response = await apiClient.get('/api/journals/dates', {
-          params: { year, month }
-        });
+        // Include query parameters in the URL since apiClient.get only accepts one parameter
+        const response = await apiClient.get<JournalDatesResponse>(`/api/journals/dates?year=${year}&month=${month}`);
         
-        if (response.dates && Array.isArray(response.dates)) {
+        if (response && response.dates && Array.isArray(response.dates)) {
           setDatesWithEntries(response.dates);
           return;
         }

--- a/apps/web/src/components/editor/extentions.ts
+++ b/apps/web/src/components/editor/extentions.ts
@@ -61,7 +61,8 @@ const taskItem = TaskItem.configure({
     class: cx("flex items-start my-4"),
   },
   nested: true,
-  onReadOnlyChecked: true,
+  // Fix: onReadOnlyChecked should be a function, not a boolean
+  onReadOnlyChecked: (node, checked) => checked,
 });
 
 const horizontalRule = HorizontalRule.configure({


### PR DESCRIPTION
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add blue dots on calendar dates with journal entries in `DailyNotes` and fix `TaskItem` configuration in `extentions.ts`.
> 
>   - **Feature**:
>     - Display blue dots on calendar dates with journal entries in `CalendarGrid` in `daily-notes.tsx`.
>     - Fetch dates with entries from API or localStorage in `fetchDatesWithEntries()` in `daily-notes.tsx`.
>   - **Fix**:
>     - Correct `onReadOnlyChecked` in `TaskItem` configuration in `extentions.ts` to be a function.
>   - **Misc**:
>     - Add `datesWithEntries` prop to `CalendarGridProps` in `daily-notes.tsx`.
>     - Update `Popover.Root` to fetch dates when calendar opens in `daily-notes.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for c157ef39ba2d9f098baf979040103eaef17916ec. You can [customize](https://app.ellipsis.dev/marchhq/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->