### PR TITLE
docker

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install bun
+RUN apk add --no-cache unzip curl bash
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Copy package files
+COPY package.json .
+COPY bun.lockb .
+
+# Install dependencies
+RUN /root/.bun/bin/bun install
+
+# Copy the rest of the application
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the application
+CMD ["/root/.bun/bin/bun", "run", "start"]

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,23 +1,38 @@
-FROM node:20-alpine
+# Build stage
+FROM oven/bun:1 as builder
 
 WORKDIR /app
-
-# Install bun
-RUN apk add --no-cache unzip curl bash
-RUN curl -fsSL https://bun.sh/install | bash
 
 # Copy package files
 COPY package.json .
 COPY bun.lockb .
 
 # Install dependencies
-RUN /root/.bun/bin/bun install
+RUN bun install --frozen-lockfile
 
 # Copy the rest of the application
 COPY . .
 
+# Production stage
+FROM oven/bun:1-slim
+
+WORKDIR /app
+
+# Copy from builder
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/index.js .
+
+# Set production environment
+ENV NODE_ENV=production
+
 # Expose the port the app runs on
-EXPOSE 3000
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:8080/health || exit 1
 
 # Start the application
-CMD ["/root/.bun/bin/bun", "run", "start"]
+CMD ["bun", "run", "start"]

--- a/apps/backend/src/loaders/environment.loader.js
+++ b/apps/backend/src/loaders/environment.loader.js
@@ -4,7 +4,7 @@ config();
 
 export const environment = {
     MONGO_URL: process.env.MONGO_URL,
-    PORT: process.env.PORT || 3000,
+    PORT: process.env.PORT || 8080,
     JWT_ISSUER: process.env.JWT_ISSUER,
     JWT_SECRET: process.env.JWT_SECRET,
     JWT_AUDIENCE: process.env.JWT_AUDIENCE,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,24 @@ services:
     build:
       context: ./apps/backend
       dockerfile: Dockerfile
+      args:
+        - NODE_ENV=production
     ports:
-      - "3000:3000"
+      - "8080:8080"
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=production
       - MONGO_URL=mongodb://mongodb:27017/march
-      - PORT=3000
+      - PORT=8080
     depends_on:
-      - mongodb
-    volumes:
-      - ./apps/backend:/app
-      - /app/node_modules
+      mongodb:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 40s
 
   mongodb:
     image: mongo:latest
@@ -23,6 +30,14 @@ services:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
+    restart: unless-stopped
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 volumes:
   mongodb_data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+      - MONGO_URL=mongodb://mongodb:27017/march
+      - PORT=3000
+    depends_on:
+      - mongodb
+    volumes:
+      - ./apps/backend:/app
+      - /app/node_modules
+
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
## **User description**
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Docker support for backend with Dockerfile and docker-compose, and update default port to 8080.
> 
>   - **Docker Support**:
>     - Adds `Dockerfile` in `apps/backend` for building and running the backend application using Bun.
>     - Adds `docker-compose.yml` to orchestrate services, including `backend` and `mongodb`.
>   - **Environment Configuration**:
>     - Changes default `PORT` from 3000 to 8080 in `environment.loader.js` to align with Docker setup.
>   - **Health Checks**:
>     - Adds health check in `Dockerfile` for backend service on port 8080.
>     - Configures health checks for `backend` and `mongodb` services in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for f9a236c6cdf3141acfd31b297f353bdad09d847b. You can [customize](https://app.ellipsis.dev/marchhq/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Added a multi-stage Dockerfile for the backend application, using Bun as the runtime, with a health check on port 8080 and optimized for production deployment.
- Introduced a docker-compose.yml file to orchestrate the backend and MongoDB services, including health checks, persistent storage for MongoDB, and appropriate environment variable configuration.
- Updated the backend's environment loader to set the default port to 8080 instead of 3000, ensuring consistency with the Docker setup.

This PR introduces full Docker support for the backend, enabling seamless containerized deployment and local development with MongoDB. The changes ensure health monitoring, persistent data storage, and standardized port usage, improving deployment reliability and developer experience.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add multi-stage Dockerfile for backend with health check and port 8080</code></dd></summary>
<hr>

apps/backend/Dockerfile
<li>Added a multi-stage Dockerfile for the backend using Bun as the <br>runtime.<br> <li> Configured build and production stages for optimized image size.<br> <li> Set up health check for the backend service on port 8080.<br> <li> Exposed port 8080 and set production environment variables.<br>


</details>
    

  </td>
  <td><a href="https://github.com/marchhq/march/pull/1010/files#diff-e6df7bc35853016a16f3654a1699502794903bcbe9c7747c944a5263ac520948">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Add docker-compose for backend and MongoDB with health checks</code>&nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml
<li>Introduced docker-compose configuration for orchestrating backend and <br>MongoDB services.<br> <li> Defined health checks for both backend and MongoDB services.<br> <li> Set up persistent volume for MongoDB data.<br> <li> Configured environment variables and port mappings for both services.<br>


</details>
    

  </td>
  <td><a href="https://github.com/marchhq/march/pull/1010/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+43/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>environment.loader.js</strong><dd><code>Update default backend port to 8080 in environment loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backend/src/loaders/environment.loader.js
<li>Changed the default backend port from 3000 to 8080 to align with <br>Docker configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/marchhq/march/pull/1010/files#diff-0035a037d983493b29a3c81b64b50cc2b9e45d0128f6a68bdd5bc95fe1775f0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
