### PR TITLE
feat: add logs

### DIFF
--- a/apps/web/src/app/api/auth/google/route.ts
+++ b/apps/web/src/app/api/auth/google/route.ts
@@ -35,13 +35,12 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     res = data as GoogleAuthResponse;
   } catch (error) {
     const e = error as AxiosError;
-
+    console.error("google auth error - full error object:", e);
     if (e.response?.status === 401) {
-      console.error("google auth error", e.response?.data);
+      console.error("google auth error - response data:", e.response?.data);
     } else {
-      console.error("google auth error", e.cause);
+      console.error("google auth error - cause:", e.cause);
     }
-
     return NextResponse.redirect(new URL("/signin", redirectUrl));
   }
 


### PR DESCRIPTION
## **User description**
# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add detailed error logging for Google authentication in `route.ts`.
> 
>   - **Logging**:
>     - Added detailed error logging in `GET` function in `route.ts` for Google authentication errors.
>     - Logs full error object, response data for 401 status, and error cause for other statuses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=marchhq%2Fmarch&utm_source=github&utm_medium=referral)<sup> for b08d63be74981e7fce71d66ce7d27f7bb64bf508. You can [customize](https://app.ellipsis.dev/marchhq/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


___

## **CodeAnt-AI Description**
- Added a `console.error` statement to log the full error object when a Google authentication error occurs.
- Improved the specificity of error logs by clearly labeling logs for 401 status (response data) and other errors (cause).
- Enhanced the clarity and detail of error messages to aid in debugging authentication issues.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Enhance and clarify error logging for Google authentication failures</code></dd></summary>
<hr>

apps/web/src/app/api/auth/google/route.ts
<li>Added a log statement to output the full error object when a Google <br>authentication error occurs.<br> <li> Improved error logging by distinguishing between 401 errors (logging <br>response data) and other errors (logging the error cause) with more <br>descriptive messages.<br> <li> Enhanced clarity and detail in error logs for easier debugging.<br>


</details>


  </td>
  <td><a href="https://github.com/marchhq/march/pull/1013/files#diff-ed239669fbc112c37d7a0197cdda07d566d024fa26288a4879e33329f570084a">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
