### PR TITLE
fix: add deployment configuration

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -5,10 +5,9 @@ WORKDIR /app
 
 # Copy package files
 COPY package.json .
-COPY bun.lockb .
 
-# Install dependencies
-RUN bun install --frozen-lockfile
+# Install dependencies without lockfile (since we don't have bun.lockb in backend dir)
+RUN bun install
 
 # Copy the rest of the application
 COPY . .
@@ -32,7 +31,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/ || exit 1
 
 # Start the application
 CMD ["bun", "run", "start"]

--- a/apps/backend/Dockerfile.railway
+++ b/apps/backend/Dockerfile.railway
@@ -1,0 +1,45 @@
+# Railway Dockerfile for Backend - use this for Railway deployment
+# This should be used from the ROOT directory of the monorepo
+
+FROM oven/bun:1 as builder
+
+WORKDIR /app
+
+# Copy root package.json and lockfile for monorepo setup
+COPY package.json .
+COPY bun.lockb .
+COPY bunfig.toml .
+
+# Copy backend package.json
+COPY apps/backend/package.json ./apps/backend/
+
+# Install all dependencies (this handles the monorepo workspace)
+RUN bun install --frozen-lockfile
+
+# Copy backend source code
+COPY apps/backend/src ./apps/backend/src
+COPY apps/backend/index.js ./apps/backend/
+
+# Production stage
+FROM oven/bun:1-slim
+
+WORKDIR /app
+
+# Copy node_modules and backend files from builder
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/backend/package.json .
+COPY --from=builder /app/apps/backend/src ./src
+COPY --from=builder /app/apps/backend/index.js .
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:8080/ || exit 1
+
+# Start the application
+CMD ["bun", "run", "start"] 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,49 @@
+# Frontend Dockerfile for Next.js
+FROM oven/bun:1 AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+WORKDIR /app
+
+# Copy package files
+COPY package.json bun.lockb* ./
+RUN bun install --frozen-lockfile --production
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Build the app
+RUN bun run build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+# Disable telemetry during runtime
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"] 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'standalone',
   images: {
     domains: ['lh3.googleusercontent.com', "fonts.gstatic.com", "avatars.githubusercontent.com"]
   },


### PR DESCRIPTION
- Fix backend Dockerfile to handle monorepo structure without bun.lockb
- Add Dockerfile.railway for proper monorepo deployment from root
- Add frontend Dockerfile with bun and standalone output
- Enable standalone output in Next.js config for Railway deployment
- Fix health check endpoints in Dockerfiles

# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added Dockerfiles and configuration updates to support monorepo deployment of both backend and frontend apps on Railway, including standalone Next.js output and improved health checks.

- **Deployment**
  - Added Dockerfile.railway for backend to handle monorepo installs from the root.
  - Added frontend Dockerfile with Bun and standalone Next.js output.
  - Updated backend Dockerfile to work without a lockfile and fixed health check endpoints.
  - Enabled standalone output in Next.js config for better deployment compatibility.

<!-- End of auto-generated description by cubic. -->

