### PR TITLE
fix: resolve frontend Docker build missing public directory

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,6 +18,9 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy all source files including TypeScript config
 COPY . .
 
+# Create public directory if it doesn't exist
+RUN mkdir -p public
+
 # Build the app
 RUN bun run build
 
@@ -32,6 +35,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+# Copy public folder (now guaranteed to exist)
 COPY --from=builder /app/public ./public
 
 # Set the correct permission for prerender cache

--- a/apps/web/Dockerfile.railway
+++ b/apps/web/Dockerfile.railway
@@ -31,6 +31,9 @@ COPY apps/web ./apps/web
 # Change to web directory for build
 WORKDIR /app/apps/web
 
+# Create public directory if it doesn't exist
+RUN mkdir -p public
+
 # Build the app
 RUN bun run build
 


### PR DESCRIPTION
- Add mkdir -p public in build stage to ensure public directory exists
- Fix COPY --from=builder /app/public ./public error when public dir missing
- Update both Dockerfile and Dockerfile.railway with the fix
- This app uses src/app/favicon.ico instead of public/favicon.ico

Resolves: failed to calculate checksum '/app/public': not found

# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Docker build error by ensuring `public` directory exists in `Dockerfile` and `Dockerfile.railway`.
> 
>   - **Docker Build Fix**:
>     - Add `RUN mkdir -p public` in `Dockerfile` and `Dockerfile.railway` to ensure `public` directory exists before copying.
>     - Fixes `COPY --from=builder /app/public ./public` error when `public` directory is missing.
>   - **Misc**:
>     - Note that the app uses `src/app/favicon.ico` instead of `public/favicon.ico`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=zerotrailai%2Fmarch&utm_source=github&utm_medium=referral)<sup> for 5caf7ca4204c2cafbf59c62e57894f98777de5a3. You can [customize](https://app.ellipsis.dev/zerotrailai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->