### PR TITLE
debug: add simplified Dockerfile and disable standalone mode

### DIFF
--- a/apps/web/Dockerfile.simple
+++ b/apps/web/Dockerfile.simple
@@ -1,0 +1,46 @@
+# Simple Next.js Dockerfile for Railway
+FROM node:18-alpine AS base
+
+# Install dependencies
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json ./
+RUN npm ci
+
+# Build the app
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN mkdir -p public
+RUN npm run build
+
+# Production image
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Use regular Next.js start instead of standalone
+COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Use npm start instead of server.js
+CMD ["npm", "start"] 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  output: 'standalone',
+  // output: 'standalone', // Disabled for debugging
   images: {
     domains: ['lh3.googleusercontent.com', "fonts.gstatic.com", "avatars.githubusercontent.com"]
   },


### PR DESCRIPTION
- Create Dockerfile.simple using regular npm start instead of standalone
- Disable standalone output mode temporarily for debugging
- Use Node.js alpine instead of bun for more predictable behavior
- Copy full .next and node_modules instead of standalone output

This should help debug the Railway 502 'Application failed to respond' error

# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a simplified Dockerfile that uses regular npm start and disabled standalone mode to help debug Railway deployment issues.

- **Refactors**
  - Switched to Node.js alpine base image and full .next/node_modules copy for more predictable builds.
  - Commented out standalone output in next.config.ts.

<!-- End of auto-generated description by cubic. -->

