### PR TITLE
fix: resolve npm ci lockfile error

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,7 +6,8 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json ./
-RUN npm ci
+# Use npm install since we don't have package-lock.json
+RUN npm install
 
 # Build the app
 FROM base AS builder

--- a/apps/web/Dockerfile.railway
+++ b/apps/web/Dockerfile.railway
@@ -16,6 +16,7 @@ COPY bunfig.toml .
 COPY apps/web/package.json ./apps/web/
 
 # Install all dependencies (this handles the monorepo workspace)
+# Use root bun.lockb since that's what this project uses
 RUN bun install
 
 # Rebuild the source code only when needed


### PR DESCRIPTION
- Replace 'npm ci' with 'npm install' since no package-lock.json exists
- This project uses bun.lockb at root level, not npm package-lock.json
- npm ci requires existing package-lock.json but npm install works without it
- Add comment explaining monorepo bun usage in Railway Dockerfile

Resolves: npm ci command can only install with existing package-lock.json

# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced 'npm ci' with 'npm install' in the Dockerfile to fix lockfile errors, and added a comment in the Railway Dockerfile to clarify bun.lockb usage.

<!-- End of auto-generated description by cubic. -->

