### PR TITLE
debug: add debugging pages and disable middleware temporarily

### DIFF
--- a/apps/web/src/app/debug/page.tsx
+++ b/apps/web/src/app/debug/page.tsx
@@ -1,0 +1,11 @@
+export default function DebugPage() {
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial' }}>
+      <h1>🔧 Debug Page</h1>
+      <p>✅ Next.js is working!</p>
+      <p>✅ Route rendering works!</p>
+      <p>✅ Environment: {process.env.NODE_ENV}</p>
+      <p>Time: {new Date().toISOString()}</p>
+    </div>
+  )
+} 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,24 @@
-import { redirect } from 'next/navigation';
-
+// Temporary debug version - no redirects or complex logic
 export default function Home() {
-  // Redirect to the landing page
-  redirect('/signin');
-  
-  // This won't be rendered due to the redirect
-  return null;
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial', textAlign: 'center' }}>
+      <h1>🚀 March App is Working!</h1>
+      <p>✅ Frontend deployed successfully</p>
+      <p>✅ Next.js is running</p>
+      <p>Time: {new Date().toISOString()}</p>
+      <div style={{ marginTop: '20px' }}>
+        <a href="/debug" style={{ color: 'blue', textDecoration: 'underline' }}>
+          → Debug page
+        </a>
+        {' | '}
+        <a href="/api/health" style={{ color: 'blue', textDecoration: 'underline' }}>
+          → Health check
+        </a>
+        {' | '}
+        <a href="/signin" style={{ color: 'blue', textDecoration: 'underline' }}>
+          → Original signin
+        </a>
+      </div>
+    </div>
+  )
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -125,10 +125,10 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   return NextResponse.next();
 }
 
-// Matcher configuration
+// Matcher configuration - DISABLED FOR DEBUGGING
 export const config = {
   matcher: [
-    // Match all paths except static files, API routes, and auth routes
-    "/((?!api|auth|_next/static|_next/image|favicon.ico).*)",
+    // TEMPORARILY DISABLED - only match debug paths to test if middleware is causing 502s
+    "/middleware-debug-only-no-real-paths",
   ],
 };


### PR DESCRIPTION
- Create /debug page to test basic Next.js functionality
- Simplify root page (/) to avoid redirects and complex logic
- Temporarily disable middleware to test if it's causing 502 errors
- Add simple static content with links to test different endpoints

This will help isolate whether the 502 is caused by:
- Middleware making backend calls during startup
- Complex page logic or redirects
- Basic Next.js server issues

# What did you ship?

<!-- Describe your changes here -->

**Fixes:**

- [ ] #XXX (GitHub issue number)
- [ ] MAR-XXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

# Checklist:
- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected)
- [ ] I pinky swear that my codes gonna work as I have testing every possible scenario. 
- [ ] I ignored Coderabbit suggestion because it does not make any sense.
- [ ] I took Coderabbit suggestion under consideration as some of it makes sense.
- [ ] I have commented my code, particularly in hard-to-understand areas.

# OR:


- [ ] shut up and let me cook.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a /debug page and simplified the home page to help isolate the cause of 502 errors. Middleware is temporarily disabled to test if it is related to the issue.

- **Debugging Changes**
  - New /debug page shows basic Next.js status.
  - Home page now displays static content with links to key endpoints.
  - Middleware only matches a non-existent path to prevent it from running.

<!-- End of auto-generated description by cubic. -->

