### PR TITLE
fix: use pg Pool for Prisma adapter

### DIFF
--- a/brain/interface/src/lib/prisma.ts
+++ b/brain/interface/src/lib/prisma.ts
@@ -1,12 +1,20 @@
 import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
+  pool: Pool | undefined;
 };
 
 function createPrismaClient(): PrismaClient {
-  const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+  const pool = globalForPrisma.pool ?? new Pool({
+    connectionString: process.env.DATABASE_URL!,
+    max: 5,
+  });
+  globalForPrisma.pool = pool;
+
+  const adapter = new PrismaPg({ pool });
   return new PrismaClient({ adapter });
 }
 


### PR DESCRIPTION
Switches Prisma PrismaPg adapter from single connectionString to pg.Pool (max 5). Fixes Connection terminated unexpectedly errors in production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a pg Pool for the Prisma adapter to stabilize database connections and prevent “Connection terminated unexpectedly” errors in production.
Creates a shared Pool (max 5) and passes it to PrismaPg; the pool is stored on globalThis to reuse across reloads.

<sup>Written for commit e8eea3f893248920731835be23babaf29450d484. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

