### PR TITLE
fix: pass pool directly to PrismaPg constructor

### DIFF
--- a/brain/interface/src/lib/prisma.ts
+++ b/brain/interface/src/lib/prisma.ts
@@ -14,7 +14,7 @@ function createPrismaClient(): PrismaClient {
   });
   globalForPrisma.pool = pool;
 
-  const adapter = new PrismaPg({ pool });
+  const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }
 


### PR DESCRIPTION
PrismaPg(poolOrConfig) takes the pool as first positional arg, not as { pool }. Fixes build failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PrismaPg adapter instantiation by passing the pool directly instead of { pool }. Resolves the build error when creating the Prisma client.

<sup>Written for commit e730922e96dc5ddd08b2d0bef4c6ee3ba1471a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

